### PR TITLE
Bump activerecord version

### DIFF
--- a/lib/low_card_tables.rb
+++ b/lib/low_card_tables.rb
@@ -42,7 +42,8 @@ class ActiveRecord::Migration
         migrate_without_low_card_connection_patching(*args, &block)
       end
 
-      alias_method_chain :migrate, :low_card_connection_patching
+      alias_method :migrate_without_low_card_connection_patching, :migrate
+      alias_method :migrate, :migrate_with_low_card_connection_patching
     end
   else
     def migrate_with_low_card_connection_patching(*args, &block)
@@ -50,7 +51,8 @@ class ActiveRecord::Migration
       migrate_without_low_card_connection_patching(*args, &block)
     end
 
-    alias_method_chain :migrate, :low_card_connection_patching
+    alias_method :migrate_without_low_card_connection_patching, :migrate
+    alias_method :migrate, :migrate_with_low_card_connection_patching
   end
 
   class << self

--- a/lib/low_card_tables/active_record/migrations.rb
+++ b/lib/low_card_tables/active_record/migrations.rb
@@ -75,10 +75,17 @@ module LowCardTables
       end
 
       included do
-        alias_method_chain :create_table, :low_card_support
-        alias_method_chain :add_column, :low_card_support
-        alias_method_chain :remove_column, :low_card_support
-        alias_method_chain :change_table, :low_card_support
+        alias_method :create_table_without_low_card_support, :create_table
+        alias_method :create_table, :create_table_with_low_card_support
+
+        alias_method :add_column_without_low_card_support, :add_column
+        alias_method :add_column, :add_column_with_low_card_support
+
+        alias_method :remove_column_without_low_card_support, :remove_column
+        alias_method :remove_column, :remove_column_with_low_card_support
+
+        alias_method :change_table_without_low_card_support, :change_table
+        alias_method :change_table, :change_table_with_low_card_support
       end
 
       class << self

--- a/lib/low_card_tables/low_card_table/row_collapser.rb
+++ b/lib/low_card_tables/low_card_table/row_collapser.rb
@@ -123,7 +123,7 @@ module LowCardTables
 
         # Figure out which rows we need to delete; this is just all the losers.
         ids_to_delete = collapse_map.values.map { |row_array| row_array.map(&:id) }.flatten.sort
-        low_card_model.delete_all([ "id IN (:ids)", { :ids => ids_to_delete } ])
+        low_card_model.where(id: ids_to_delete).delete_all
 
         # Figure out what referring models we need to update.
         all_referring_models = low_card_model.low_card_referring_models | (additional_referring_models || [ ])

--- a/lib/low_card_tables/version_support.rb
+++ b/lib/low_card_tables/version_support.rb
@@ -38,19 +38,11 @@ module LowCardTables
             klass.instance_eval %{
     default_scope { where(#{conditions.inspect}) }
 }
-          else
-            klass.instance_eval %{
-    default_scope { }
-}
           end
         else
           if conditions
             klass.instance_eval %{
     default_scope where(#{conditions.inspect})
-}
-          else
-            klass.instance_eval %{
-    default_scope nil
 }
           end
         end

--- a/low_card_tables.gemspec
+++ b/low_card_tables.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   ar_version = ar_version.strip if ar_version
 
   version_spec = case ar_version
-  when nil then [ ">= 3.0", "<= 4.99.99" ]
+  when nil then [ ">= 3.0", "<= 5.99.99" ]
   when 'master' then nil
   else [ "=#{ar_version}" ]
   end
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
     s.add_dependency("activerecord", *version_spec)
   end
 
-  s.add_dependency "activesupport", ">= 3.0", "<= 4.99.99"
+  s.add_dependency "activesupport", ">= 3.0", "<= 5.99.99"
 
   ar_import_version = case ar_version
   when nil then nil

--- a/spec/low_card_tables/helpers/system_helpers.rb
+++ b/spec/low_card_tables/helpers/system_helpers.rb
@@ -4,8 +4,10 @@ require 'active_record/migration'
 module LowCardTables
   module Helpers
     module SystemHelpers
+      MIGRATION_CLASS_BREAKING_VERSION = 5
+
       def migrate(&block)
-        migration_class = Class.new(::ActiveRecord::Migration)
+        migration_class = Class.new(migration_class_parent)
         metaclass = migration_class.class_eval { class << self; self; end }
         metaclass.instance_eval { define_method(:up, &block) }
 
@@ -58,6 +60,12 @@ module LowCardTables
           drop_table :lctables_spec_user_statuses rescue nil
           drop_table :lctables_spec_users rescue nil
         end
+      end
+
+      def migration_class_parent
+        return ::ActiveRecord::Migration if ::ActiveRecord::VERSION::STRING.to_f < MIGRATION_CLASS_BREAKING_VERSION
+
+        ::ActiveRecord::Migration[::ActiveRecord::VERSION::STRING.to_f]
       end
     end
   end

--- a/spec/low_card_tables/system/migrations_system_spec.rb
+++ b/spec/low_card_tables/system/migrations_system_spec.rb
@@ -364,7 +364,7 @@ describe "LowCardTables migration support" do
         new_status.id.should_not == status_1.id
         new_status.id.should > 0
 
-        ::UserStatus.delete_all("id = #{new_status.id}")
+        ::UserStatus.where(id: new_status.id).delete_all
       end
     end
   end

--- a/spec/low_card_tables/system/validations_system_spec.rb
+++ b/spec/low_card_tables/system/validations_system_spec.rb
@@ -83,6 +83,6 @@ describe "LowCardTables validation support" do
     e.message.should match(/lctables_spec_user_statuses/mi)
     e.message.should match(/gender/mi)
     e.message.should match(/nil/mi)
-    e.message.should match(/ActiveRecord::StatementInvalid/mi)
+    e.message.should match(/ActiveRecord::StatementInvalid|ActiveRecord::NotNullViolation/mi)
   end
 end

--- a/spec/low_card_tables/unit/low_card_table/row_collapser_spec.rb
+++ b/spec/low_card_tables/unit/low_card_table/row_collapser_spec.rb
@@ -69,7 +69,8 @@ describe LowCardTables::LowCardTable::RowCollapser do
       context "actual collapsing" do
         before :each do
           expect(@low_card_model).to receive(:all).and_return([ @row1, @row2, @row3, @row4, @row5, @row6 ])
-          expect(@low_card_model).to receive(:delete_all).once.with([ "id IN (:ids)", { :ids => [ 2, 3, 5, 6 ]} ])
+          expect(@low_card_model).to receive(:where).with(id: [ 2, 3, 5, 6 ]).and_return(@low_card_model)
+          expect(@low_card_model).to receive(:delete_all).once
 
           @expected_collapse_map = { @row1 => [ @row2, @row3 ], @row4 => [ @row5, @row6 ]}
         end

--- a/spec/low_card_tables/unit/low_card_table/row_manager_spec.rb
+++ b/spec/low_card_tables/unit/low_card_table/row_manager_spec.rb
@@ -119,6 +119,10 @@ describe LowCardTables::LowCardTable::RowManager do
           raise "created a cache that we didn't expect to create"
         end
       end
+      connection = double('connection')
+      allow(::ActiveRecord::Base).to receive(:connection).and_return(connection)
+      allow(connection).to receive(:type_cast).with(nil, @column_foo).and_return(nil)
+      allow(connection).to receive(:type_cast).with('yohoho', @column_bar).and_return('yohoho')
 
       @expected_stale_calls = [ ]
       esc = @expected_stale_calls

--- a/spec/low_card_tables/unit/low_card_table/table_unique_index_spec.rb
+++ b/spec/low_card_tables/unit/low_card_table/table_unique_index_spec.rb
@@ -70,7 +70,7 @@ describe LowCardTables::LowCardTable::TableUniqueIndex do
         allow(@connection).to receive(:indexes).with("foobar") { index_return_values.shift }
 
         our_migration_class = Class.new
-        allow(Class).to receive(:new).once.with(::ActiveRecord::Migration).and_return(our_migration_class)
+        allow(Class).to receive(:new).once.and_return(our_migration_class)
 
         expect(our_migration_class).to receive(:migrate).once.with(:up)
 
@@ -100,7 +100,7 @@ describe LowCardTables::LowCardTable::TableUniqueIndex do
         allow(@connection).to receive(:indexes).with("foobar") { index_return_values.shift }
 
         our_migration_class = Class.new
-        allow(Class).to receive(:new).once.with(::ActiveRecord::Migration).and_return(our_migration_class)
+        allow(Class).to receive(:new).once.and_return(our_migration_class)
 
         expect(our_migration_class).to receive(:migrate).once.with(:up)
 


### PR DESCRIPTION
### Description
With new versions of Rails, it's required to bump `activerecord` dependency step by step.

This PR is dedicated to bump `activerecord` version