### PR TITLE
Bump low_card_tables gem to 1.1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # `low_card_tables` Changelog
 
+## 1.1.2,
+
+Add Rails 5 support
+
+
 ## 1.1.1,
 
 * Fixed an issue where, if you installed another ActiveRecord-related gem installed that defined a method `primary_keys` on a model that returned an empty array, `low_card_tables` would incorrectly behave as if the low-card table had no primary key at all, and expect you to include `id` in the all-columns index.

--- a/lib/low_card_tables/version.rb
+++ b/lib/low_card_tables/version.rb
@@ -1,4 +1,4 @@
 # Defines the current version of +low_card_tables+.
 module LowCardTables
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end


### PR DESCRIPTION
### Description
In order to resolve conflicts with the original gem, it's required to bump the gem version to `1.1.2`.

This PR is dedicated to bumping the gem version to `1.1.2`