### PR TITLE
Bump ActiveRecord version to support Rails 6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # `low_card_tables` Changelog
 
+## 1.1.3
+
+Add Rails 6 support
+
 ## 1.1.2,
 
 Add Rails 5 support

--- a/lib/low_card_tables.rb
+++ b/lib/low_card_tables.rb
@@ -5,6 +5,7 @@ require "low_card_tables/version"
 require "low_card_tables/version_support"
 require 'low_card_tables/active_record/base'
 require 'low_card_tables/active_record/migrations'
+require 'low_card_tables/active_record/querying'
 require 'low_card_tables/active_record/relation'
 require 'low_card_tables/active_record/scoping'
 require 'low_card_tables/low_card_table/cache_expiration/has_cache_expiration'
@@ -28,6 +29,7 @@ end
 class ActiveRecord::Base
   include LowCardTables::ActiveRecord::Base
   include LowCardTables::ActiveRecord::Scoping
+  extend LowCardTables::ActiveRecord::Querying
 end
 
 # ActiveRecord migration methods (e.g., #create_table, #remove_column, etc.) are actually defined on the connection

--- a/lib/low_card_tables/active_record/querying.rb
+++ b/lib/low_card_tables/active_record/querying.rb
@@ -1,0 +1,22 @@
+module LowCardTables
+  module ActiveRecord
+    module Querying
+      # Overrides ::ActiveRecord::Querying#find_by_sql to add support for low-card inherited tables.
+      def find_by_sql(sql, binds = [], preparable: nil, &block)
+        result_set = connection.select_all(sanitize_sql(sql), "#{name} Load", binds, preparable: preparable)
+        column_types = result_set.column_types.dup
+        attribute_types.each_key { |k| column_types.delete k }
+        message_bus = ActiveSupport::Notifications.instrumenter
+
+        payload = {
+          record_count: result_set.length,
+          class_name: name
+        }
+
+        message_bus.instrument("instantiation.active_record", payload) do
+          result_set.map { |record| instantiate(record, column_types, &block) }
+        end
+      end
+    end
+  end
+end

--- a/lib/low_card_tables/version.rb
+++ b/lib/low_card_tables/version.rb
@@ -1,4 +1,4 @@
 # Defines the current version of +low_card_tables+.
 module LowCardTables
-  VERSION = "1.1.2"
+  VERSION = "1.1.3"
 end

--- a/lib/low_card_tables/version_support.rb
+++ b/lib/low_card_tables/version_support.rb
@@ -28,7 +28,7 @@ module LowCardTables
       end
 
       def allows_static_scopes?
-        (::ActiveRecord::VERSION::MAJOR < 4) || (::ActiveRecord::VERSION::MINOR < 2)
+        ::ActiveRecord::VERSION::MAJOR < 6 && (::ActiveRecord::VERSION::MAJOR < 4 || ::ActiveRecord::VERSION::MINOR < 2)
       end
 
       # Define a default scope on the class in question. This is only actually used from our specs.

--- a/low_card_tables.gemspec
+++ b/low_card_tables.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   ar_version = ar_version.strip if ar_version
 
   version_spec = case ar_version
-  when nil then [ ">= 3.0", "<= 5.99.99" ]
+  when nil then [ ">= 3.0", "< 7" ]
   when 'master' then nil
   else [ "=#{ar_version}" ]
   end
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
     s.add_dependency("activerecord", *version_spec)
   end
 
-  s.add_dependency "activesupport", ">= 3.0", "<= 5.99.99"
+  s.add_dependency "activesupport", ">= 3.0", "< 7"
 
   ar_import_version = case ar_version
   when nil then nil

--- a/spec/low_card_tables/unit/active_record/migrations_spec.rb
+++ b/spec/low_card_tables/unit/active_record/migrations_spec.rb
@@ -61,7 +61,7 @@ describe LowCardTables::ActiveRecord::Migrations do
         temp_class = Class.new
         expect(Class).to receive(:new).once.with(::ActiveRecord::Base).and_return(temp_class).ordered
         expect(temp_class).to receive(:table_name=).once.with(:foo).ordered
-        expect(temp_class).to receive(:is_low_card_table).once.with().ordered
+        expect(temp_class).to receive(:is_low_card_table).once.with(no_args).ordered
         expect(temp_class).to receive(:reset_column_information).once.ordered
 
         expect(temp_class).to receive(:low_card_remove_unique_index!).once.ordered

--- a/spec/low_card_tables/unit/low_card_table/row_manager_spec.rb
+++ b/spec/low_card_tables/unit/low_card_table/row_manager_spec.rb
@@ -892,7 +892,7 @@ describe LowCardTables::LowCardTable::RowManager do
       expect(LowCardTables::LowCardTable::RowCollapser).to receive(:new).once.with(@low_card_model, { :abc => :def }).and_return(collapser)
 
       collapse_map = double("collapse_map")
-      expect(collapser).to receive(:collapse!).once.with().and_return(collapse_map)
+      expect(collapser).to receive(:collapse!).once.with(no_args).and_return(collapse_map)
 
       @instance.collapse_rows_and_update_referrers!(:abc => :def).should be(collapse_map)
 


### PR DESCRIPTION
## https://github.com/elastic/search-developer-productivity/issues/2642

### Description
In order to proceed with the Rails 6 upgrade, it's required to bump `activerecord` maximum version to 7 and fix deprecation warnings.

This PR is dedicated to bumping `activerecord`