### PR TITLE
Bump the gem version to 1.1.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # `low_card_tables` Changelog
 
+## 1.1.4
+
+Add Ruby 3 support
+
 ## 1.1.3
 
 Add Rails 6 support

--- a/lib/low_card_tables/version.rb
+++ b/lib/low_card_tables/version.rb
@@ -1,4 +1,4 @@
 # Defines the current version of +low_card_tables+.
 module LowCardTables
-  VERSION = "1.1.3"
+  VERSION = "1.1.4"
 end


### PR DESCRIPTION
After merging this [PR](https://github.com/swiftype/low_card_tables/pull/4), it's required to bump the gem version to `1.1.4`

This RP is dedicated to bumping the gem version to `1.1.4`